### PR TITLE
Fix venue amount input showing leading zero issue

### DIFF
--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -617,7 +617,7 @@ export default function EventDetailPage() {
                         <label className="text-xs text-gray-600">総金額</label>
                         <input
                           type="number"
-                          value={editVenueData?.totalAmount || 0}
+                          value={editVenueData?.totalAmount === 0 ? '' : editVenueData?.totalAmount || ''}
                           onChange={(e) => setEditVenueData(prev => prev ? {...prev, totalAmount: parseInt(e.target.value) || 0} : null)}
                           className="w-full px-2 py-1 border rounded text-sm"
                           placeholder="総金額"
@@ -725,7 +725,7 @@ export default function EventDetailPage() {
                   <label className="text-xs text-gray-600">総金額</label>
                   <input
                     type="number"
-                    value={newVenue.totalAmount}
+                    value={newVenue.totalAmount === 0 ? '' : newVenue.totalAmount}
                     onChange={(e) => setNewVenue(prev => ({...prev, totalAmount: parseInt(e.target.value) || 0}))}
                     className="w-full px-2 py-1 border rounded text-sm"
                     placeholder="総金額"

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -512,7 +512,7 @@ export default function NewEventPage() {
                             <label className="text-xs text-gray-600">総金額</label>
                             <input
                               type="number"
-                              value={editVenueData?.totalAmount || 0}
+                              value={editVenueData?.totalAmount === 0 ? '' : editVenueData?.totalAmount || ''}
                               onChange={(e) => setEditVenueData(prev => prev ? {...prev, totalAmount: parseInt(e.target.value) || 0} : null)}
                               className="w-full px-2 py-1 border rounded text-sm"
                               placeholder="総金額"
@@ -626,7 +626,7 @@ export default function NewEventPage() {
                 </label>
                 <input
                   type="number"
-                  value={currentVenue.totalAmount}
+                  value={currentVenue.totalAmount === 0 ? '' : currentVenue.totalAmount}
                   onChange={(e) => setCurrentVenue(prev => ({ ...prev, totalAmount: parseInt(e.target.value) || 0 }))}
                   placeholder="例: 18000"
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"


### PR DESCRIPTION
- Fix number input fields displaying "01" when user enters "1"
- Apply fix to all venue amount input fields in both pages
- Use conditional value display: show empty string when amount is 0
- Maintain proper number parsing and validation logic

Fixed locations:
- New event page: venue creation and edit forms
- Event detail page: venue edit and add forms

The issue occurred because number input with initial value 0 would display "01" when user typed "1". Now shows empty field when value is 0, preventing the leading zero display issue.

Resolves: GitHub Issue #7

🤖 Generated with [Claude Code](https://claude.ai/code)