### PR TITLE
fix: PC画面でのお店追加フィールドの高さを統一

### DIFF
--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -543,7 +543,7 @@ export default function EventDetailPage() {
                     {editingVenue === venue.id ? (
                       // 編集フォーム
                       <div className="p-3 bg-blue-50 rounded-md border border-blue-200">
-                        <div className="grid md:grid-cols-2 gap-3 mb-3">
+                        <div className="grid md:grid-cols-3 gap-3 mb-3">
                           <div>
                             <label className="text-xs text-gray-600">店名</label>
                             <input
@@ -564,21 +564,21 @@ export default function EventDetailPage() {
                               placeholder="総金額"
                             />
                           </div>
-                        </div>
-                        <div className="mb-3">
-                          <label className="text-xs text-gray-600">支払者</label>
-                          <select
-                            value={editVenueData?.paidBy || ''}
-                            onChange={(e) => setEditVenueData(prev => prev ? {...prev, paidBy: e.target.value} : null)}
-                            className="w-full px-2 py-1 border rounded text-sm"
-                          >
-                            <option value="">選択してください</option>
-                            {event.participants.map((participant) => (
-                              <option key={participant.id} value={participant.nickname}>
-                                {participant.nickname}
-                              </option>
-                            ))}
-                          </select>
+                          <div>
+                            <label className="text-xs text-gray-600">支払者</label>
+                            <select
+                              value={editVenueData?.paidBy || ''}
+                              onChange={(e) => setEditVenueData(prev => prev ? {...prev, paidBy: e.target.value} : null)}
+                              className="w-full px-2 py-1 border rounded text-sm"
+                            >
+                              <option value="">選択してください</option>
+                              {event.participants.map((participant) => (
+                                <option key={participant.id} value={participant.nickname}>
+                                  {participant.nickname}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
                         </div>
                         <div className="mb-3">
                           <label className="text-xs text-gray-600">Google Maps URL (任意)</label>
@@ -652,7 +652,7 @@ export default function EventDetailPage() {
             {showAddVenue && (
               <div className="mt-4 p-3 bg-green-50 rounded-md border border-green-200">
                 <h4 className="font-medium text-gray-900 mb-3">新しいお店を追加</h4>
-                <div className="grid md:grid-cols-2 gap-3 mb-3">
+                <div className="grid md:grid-cols-3 gap-3 mb-3">
                   <div>
                     <label className="text-xs text-gray-600">店名</label>
                     <input
@@ -673,21 +673,21 @@ export default function EventDetailPage() {
                       placeholder="総金額"
                     />
                   </div>
-                </div>
-                <div className="mb-3">
-                  <label className="text-xs text-gray-600">支払者</label>
-                  <select
-                    value={newVenue.paidBy}
-                    onChange={(e) => setNewVenue(prev => ({...prev, paidBy: e.target.value}))}
-                    className="w-full px-2 py-1 border rounded text-sm"
-                  >
-                    <option value="">選択してください</option>
-                    {event.participants.map((participant) => (
-                      <option key={participant.id} value={participant.nickname}>
-                        {participant.nickname}
-                      </option>
-                    ))}
-                  </select>
+                  <div>
+                    <label className="text-xs text-gray-600">支払者</label>
+                    <select
+                      value={newVenue.paidBy}
+                      onChange={(e) => setNewVenue(prev => ({...prev, paidBy: e.target.value}))}
+                      className="w-full px-2 py-1 border rounded text-sm"
+                    >
+                      <option value="">選択してください</option>
+                      {event.participants.map((participant) => (
+                        <option key={participant.id} value={participant.nickname}>
+                          {participant.nickname}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
                 <div className="mb-3">
                   <label className="text-xs text-gray-600">Google Maps URL (任意)</label>

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -753,40 +753,51 @@ export default function NewEventPage() {
                     min="1"
                   />
                 </div>
-                <input
-                  type="text"
-                  value={currentVenue.name}
-                  onChange={(e) => setCurrentVenue(prev => ({ ...prev, name: e.target.value }))}
-                  className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="店名"
-                />
-                <input
-                  type="number"
-                  value={currentVenue.totalAmount === 0 ? '' : currentVenue.totalAmount}
-                  onChange={(e) => setCurrentVenue(prev => ({ ...prev, totalAmount: parseInt(e.target.value) || 0 }))}
-                  className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="総金額"
-                />
-                <select
-                  value={currentVenue.paidBy}
-                  onChange={(e) => setCurrentVenue(prev => ({ ...prev, paidBy: e.target.value }))}
-                  className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="">支払者を選択</option>
-                  {formData.participants.map((participant) => (
-                    <option key={participant.nickname} value={participant.nickname}>
-                      {participant.nickname}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  onClick={addVenue}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-                >
-                  <Plus className="w-4 h-4 inline mr-1" />
-                  追加
-                </button>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">店名</label>
+                  <input
+                    type="text"
+                    value={currentVenue.name}
+                    onChange={(e) => setCurrentVenue(prev => ({ ...prev, name: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    placeholder="店名"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">総金額</label>
+                  <input
+                    type="number"
+                    value={currentVenue.totalAmount === 0 ? '' : currentVenue.totalAmount}
+                    onChange={(e) => setCurrentVenue(prev => ({ ...prev, totalAmount: parseInt(e.target.value) || 0 }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    placeholder="総金額"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">支払者</label>
+                  <select
+                    value={currentVenue.paidBy}
+                    onChange={(e) => setCurrentVenue(prev => ({ ...prev, paidBy: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="">支払者を選択</option>
+                    {formData.participants.map((participant) => (
+                      <option key={participant.nickname} value={participant.nickname}>
+                        {participant.nickname}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex items-end">
+                  <button
+                    type="button"
+                    onClick={addVenue}
+                    className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+                  >
+                    <Plus className="w-4 h-4 inline mr-1" />
+                    追加
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -808,49 +819,60 @@ export default function NewEventPage() {
                             min="1"
                           />
                         </div>
-                        <input
-                          type="text"
-                          value={editVenueData?.name || ''}
-                          onChange={(e) => setEditVenueData(prev => prev ? {...prev, name: e.target.value} : null)}
-                          className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                          placeholder="店名"
-                        />
-                        <input
-                          type="number"
-                          value={editVenueData?.totalAmount === 0 ? '' : editVenueData?.totalAmount || ''}
-                          onChange={(e) => setEditVenueData(prev => prev ? {...prev, totalAmount: parseInt(e.target.value) || 0} : null)}
-                          className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                          placeholder="総金額"
-                        />
-                        <select
-                          value={editVenueData?.paidBy || ''}
-                          onChange={(e) => setEditVenueData(prev => prev ? {...prev, paidBy: e.target.value} : null)}
-                          className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        >
-                          <option value="">支払者を選択</option>
-                          {formData.participants.map((participant) => (
-                            <option key={participant.nickname} value={participant.nickname}>
-                              {participant.nickname}
-                            </option>
-                          ))}
-                        </select>
-                        <div className="flex space-x-2">
-                          <button
-                            type="button"
-                            onClick={saveVenue}
-                            className="px-3 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+                        <div>
+                          <label className="block text-xs text-gray-600 mb-1">店名</label>
+                          <input
+                            type="text"
+                            value={editVenueData?.name || ''}
+                            onChange={(e) => setEditVenueData(prev => prev ? {...prev, name: e.target.value} : null)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="店名"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-600 mb-1">総金額</label>
+                          <input
+                            type="number"
+                            value={editVenueData?.totalAmount === 0 ? '' : editVenueData?.totalAmount || ''}
+                            onChange={(e) => setEditVenueData(prev => prev ? {...prev, totalAmount: parseInt(e.target.value) || 0} : null)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="総金額"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-600 mb-1">支払者</label>
+                          <select
+                            value={editVenueData?.paidBy || ''}
+                            onChange={(e) => setEditVenueData(prev => prev ? {...prev, paidBy: e.target.value} : null)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                           >
-                            <Save className="w-4 h-4 inline mr-1" />
-                            保存
-                          </button>
-                          <button
-                            type="button"
-                            onClick={cancelEditVenue}
-                            className="px-3 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600"
-                          >
-                            <X className="w-4 h-4 inline mr-1" />
-                            キャンセル
-                          </button>
+                            <option value="">支払者を選択</option>
+                            {formData.participants.map((participant) => (
+                              <option key={participant.nickname} value={participant.nickname}>
+                                {participant.nickname}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="flex items-end">
+                          <div className="flex space-x-2 w-full">
+                            <button
+                              type="button"
+                              onClick={saveVenue}
+                              className="flex-1 px-3 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+                            >
+                              <Save className="w-4 h-4 inline mr-1" />
+                              保存
+                            </button>
+                            <button
+                              type="button"
+                              onClick={cancelEditVenue}
+                              className="flex-1 px-3 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600"
+                            >
+                              <X className="w-4 h-4 inline mr-1" />
+                              キャンセル
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- PC画面での「新しいお店を追加」フィールドで「次会」フィールドの高さが他のフィールドと一致していない問題を修正
- 全フィールドに統一されたラベルとスタイルを適用し、一貫したUI/UXを実現

## Changes
- **新規作成ページ** (`src/app/events/new/page.tsx`): 
  - 「次会」フィールドを他のフィールドと同じ構造に修正
  - 全フィールドに統一されたラベルを追加
  - ボタン配置を改善（5列グリッドで統一）
- **詳細ページ** (`src/app/events/[id]/page.tsx`):
  - お店追加・編集フォームのフィールド配置を統一
  - 2列から3列グリッドに変更してレスポンシブレイアウトを改善

## Test plan
- [x] 新規作成ページでの「次会」フィールドの高さ確認
- [x] 詳細ページでのお店追加フォームの高さ確認
- [x] 編集モードでのフィールド配置確認
- [x] レスポンシブデザインの動作確認

## Before/After
**Before**: 「次会」フィールドのみ特別な構造で高さが不一致
**After**: 全フィールドが統一された高さとラベル構造

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)