### PR TITLE
fix: 新規飲み会作成ページのモバイルレスポンシブ対応

### DIFF
--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -443,9 +443,9 @@ export default function NewEventPage() {
     <>
       <ClientLogger componentName="NewEventPage" />
       <div className="container mx-auto px-4 py-8 max-w-4xl">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">新しい飲み会を作成</h1>
-          <div className="flex items-center space-x-4">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">新しい飲み会を作成</h1>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
             <div className="text-sm text-gray-500 bg-gray-100 px-3 py-1 rounded-full">
               💾 データは自動保存されています
             </div>


### PR DESCRIPTION
## Summary
- モバイル画面で「💾 データは自動保存されています」と「⚙️ 設定画面で傾斜を調整できます」メッセージが横一列で窮屈だった問題を解決
- レスポンシブデザインを実装し、モバイルでは縦並び、デスクトップでは横並びに変更

## Changes
- **レスポンシブレイアウト**: `flex-col sm:flex-row`でモバイル/デスクトップに対応
- **スペーシング改善**: `gap-3 sm:gap-4`で適切な間隔を設定
- **構造簡素化**: `justify-between`を削除してシンプルな構造に変更
- **タイトル間隔**: タイトルとメッセージ間に適切な余白を追加

## Test plan
- [x] モバイル画面での縦並び表示確認
- [x] デスクトップ画面での横並び表示確認
- [x] タブレットサイズでの表示確認
- [x] 各ブレークポイントでの動作確認

## Before/After
**Before**: 
- モバイルで横一列に並び窮屈
- `justify-between`で左右に分かれる

**After**:
- モバイルで縦並びですっきり
- デスクトップでは横並びを維持
- 適切な間隔でUIが改善

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)