### PR TITLE
feat: 精算機能のUI改善とLINE用メッセージ生成機能を追加

### DIFF
--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -139,7 +139,7 @@ export default function EventDetailPage() {
 
   const generateSettlementMessage = (summary: PaymentSummary, participantTransfers: SettlementTransfer[]) => {
     let message = `【精算のお願い】\n${summary.nickname}さん\n\n`
-    message += `お疲れさまでした！\n`
+    message += `ありがとうございました！\n`
     message += `${event?.title || '飲み会'} の精算をお願いします。\n\n`
     
     message += `■ 精算内容\n`
@@ -842,8 +842,8 @@ export default function EventDetailPage() {
               <div className="space-y-6">
                 {paymentSummaries.map((summary) => (
                   <div key={summary.nickname} className="bg-white border rounded-lg p-4">
-                    <div className="flex items-center justify-between mb-4">
-                      <h3 className="text-lg font-semibold text-gray-900">
+                    <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
+                      <h3 className="text-base sm:text-lg font-semibold text-gray-900 flex-shrink-0">
                         {summary.nickname}さんの精算結果
                       </h3>
                       <button
@@ -852,10 +852,10 @@ export default function EventDetailPage() {
                           const message = generateSettlementMessage(summary, participantTransfers)
                           copyToClipboard(message, summary.nickname)
                         }}
-                        className="px-3 py-2 bg-green-600 text-white text-sm rounded-md hover:bg-green-700 transition-colors flex items-center space-x-1"
+                        className="px-3 py-2 sm:px-4 sm:py-2.5 bg-green-600 text-white text-xs sm:text-sm rounded-md hover:bg-green-700 transition-colors flex items-center space-x-1.5 flex-shrink-0"
                       >
-                        <Send className="w-4 h-4" />
-                        <span>精算をお願い</span>
+                        <Send className="w-3 h-3 sm:w-4 sm:h-4" />
+                        <span className="whitespace-nowrap">精算をお願い</span>
                       </button>
                     </div>
                     
@@ -867,15 +867,15 @@ export default function EventDetailPage() {
                           className="flex items-center justify-center w-full hover:bg-gray-50 rounded-lg p-2 transition-colors"
                         >
                           <div>
-                            <div className="text-2xl font-bold text-blue-600">
+                            <div className="text-xl sm:text-2xl font-bold text-blue-600">
                               ¥{formatCurrency(summary.totalPaid)}
                             </div>
-                            <div className="text-sm text-gray-600 flex items-center justify-center">
+                            <div className="text-xs sm:text-sm text-gray-600 flex items-center justify-center">
                               支払い総額
                               {expandedAccordions[`paid-${summary.nickname}`] ? (
-                                <ChevronDown className="w-4 h-4 ml-1" />
+                                <ChevronDown className="w-3 h-3 sm:w-4 sm:h-4 ml-1" />
                               ) : (
-                                <ChevronRight className="w-4 h-4 ml-1" />
+                                <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4 ml-1" />
                               )}
                             </div>
                           </div>
@@ -914,15 +914,15 @@ export default function EventDetailPage() {
                           className="flex items-center justify-center w-full hover:bg-gray-50 rounded-lg p-2 transition-colors"
                         >
                           <div>
-                            <div className="text-2xl font-bold text-green-600">
+                            <div className="text-xl sm:text-2xl font-bold text-green-600">
                               ¥{formatCurrency(summary.totalOwed)}
                             </div>
-                            <div className="text-sm text-gray-600 flex items-center justify-center">
+                            <div className="text-xs sm:text-sm text-gray-600 flex items-center justify-center">
                               負担総額
                               {expandedAccordions[`owed-${summary.nickname}`] ? (
-                                <ChevronDown className="w-4 h-4 ml-1" />
+                                <ChevronDown className="w-3 h-3 sm:w-4 sm:h-4 ml-1" />
                               ) : (
-                                <ChevronRight className="w-4 h-4 ml-1" />
+                                <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4 ml-1" />
                               )}
                             </div>
                           </div>
@@ -976,15 +976,15 @@ export default function EventDetailPage() {
                           className="flex items-center justify-center w-full hover:bg-gray-50 rounded-lg p-2 transition-colors"
                         >
                           <div>
-                            <div className={`text-2xl font-bold ${summary.balance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                            <div className={`text-xl sm:text-2xl font-bold ${summary.balance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                               ¥{formatCurrency(summary.balance)}
                             </div>
-                            <div className="text-sm text-gray-600 flex items-center justify-center">
+                            <div className="text-xs sm:text-sm text-gray-600 flex items-center justify-center">
                               差額
                               {expandedAccordions[`balance-${summary.nickname}`] ? (
-                                <ChevronDown className="w-4 h-4 ml-1" />
+                                <ChevronDown className="w-3 h-3 sm:w-4 sm:h-4 ml-1" />
                               ) : (
-                                <ChevronRight className="w-4 h-4 ml-1" />
+                                <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4 ml-1" />
                               )}
                             </div>
                           </div>

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -761,7 +761,7 @@ export default function EventDetailPage() {
                           <div className={`px-2 py-1 rounded text-xs font-medium ${isDefault ? 'bg-gray-200 text-gray-700' : 'bg-green-200 text-green-800'}`}>
                             {isDefault ? 'デフォルト設定' : 'カスタム設定'}を使用
                           </div>
-                          <div className="grid md:grid-cols-2 gap-3">
+                          <div className="grid md:grid-cols-3 gap-3">
                             <div>
                               <span className="font-medium">性別調整:</span>
                               <div className="ml-2">
@@ -778,6 +778,13 @@ export default function EventDetailPage() {
                                 フラット {config.roleMultiplier?.flat || 1.0}倍
                               </div>
                             </div>
+                            <div>
+                              <span className="font-medium">滞在時間調整:</span>
+                              <div className="ml-2 text-xs">
+                                各参加者の滞在時間の割合（0.0〜1.0）に応じて支払額を自動調整。<br/>
+                                例: 3次会を70%参加の場合、その会の支払いは70%になります。
+                              </div>
+                            </div>
                           </div>
                         </div>
                       )
@@ -788,7 +795,8 @@ export default function EventDetailPage() {
                             デフォルト設定を使用
                           </div>
                           <div className="text-xs">
-                            性別・役割による調整なし（全員1.0倍）
+                            性別・役割による調整なし（全員1.0倍）<br/>
+                            滞在時間による調整は各参加者の参加率に応じて自動適用されます
                           </div>
                         </div>
                       )

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -855,7 +855,7 @@ export default function EventDetailPage() {
                         className="px-3 py-2 sm:px-4 sm:py-2.5 bg-green-600 text-white text-xs sm:text-sm rounded-md hover:bg-green-700 transition-colors flex items-center space-x-1.5 flex-shrink-0"
                       >
                         <Send className="w-3 h-3 sm:w-4 sm:h-4" />
-                        <span className="whitespace-nowrap">精算をお願い</span>
+                        <span className="whitespace-nowrap"> 精算をお願い</span>
                       </button>
                     </div>
                     

--- a/src/lib/settlement.ts
+++ b/src/lib/settlement.ts
@@ -135,6 +135,8 @@ export function calculatePaymentSummary(event: Event, settlements: SettlementCal
   const { participants, venues } = event
 
   console.log('💰 [calculatePaymentSummary] 支払いサマリー計算開始')
+  console.log('💰 [calculatePaymentSummary] settlements:', settlements.map(s => ({ participantId: s.participantId, amount: s.amount })))
+  console.log('💰 [calculatePaymentSummary] participants:', participants.map(p => ({ id: p.id, nickname: p.nickname })))
 
   return participants.map(participant => {
     // 実際に支払った金額を計算
@@ -149,6 +151,8 @@ export function calculatePaymentSummary(event: Event, settlements: SettlementCal
     const settlement = settlements.find(s => s.participantId === participant.id)
     const totalOwed = settlement?.amount || 0
     
+    console.log(`💰 [calculatePaymentSummary] ${participant.nickname}さん(ID:${participant.id})の精算検索:`)
+    console.log(`  - 検索したsettlement:`, settlement)
     console.log(`  - 負担義務額: ¥${totalOwed}`)
 
     // 差額を計算（正の値：お金をもらう、負の値：支払う）


### PR DESCRIPTION
## Summary
- 精算ボタン押下後の設定セクションに滞在時間による傾斜配分の記載を追加
- 精算結果をアコーディオン化して計算過程を詳細表示
- コピーアイコンを「精算をお願い」ボタンに変更してLINE用メッセージ生成機能を実装
- iPhone SE対応のモバイル表示最適化

## 主な変更内容

### 1. 設定セクションの改善
- 「使用した設定」セクションに滞在時間による傾斜配分の説明を追加
- カスタム設定とデフォルト設定の両方に対応

### 2. 精算結果のアコーディオン化
- 支払い総額、負担総額、差額をクリック可能なアコーディオンに変更
- 各項目の計算過程を詳細表示
- 支払い詳細：実際に支払ったお店と金額の内訳
- 負担詳細：各次会での基本金額、調整係数、最終負担額
- 差額詳細：支払い総額と負担総額の差額計算過程

### 3. LINE用精算依頼メッセージ機能
- コピーアイコンを「精算をお願い」ボタンに変更
- 詳細版フォーマットでLINE用メッセージを自動生成
- 飲み会名、精算内容、精算方法を含む丁寧なメッセージ
- クリップボードへの自動コピーとフィードバック表示

### 4. モバイル表示最適化
- iPhone SE対応でタイトルとボタンの文字サイズを調整
- 改行を防止するレスポンシブ対応
- ボタンの余白とアイコン配置を最適化

## Test plan
- [x] 精算計算後に「使用した設定」に滞在時間調整の説明が表示される
- [x] 支払い総額、負担総額、差額のアコーディオンが正常に動作する
- [x] 計算過程の詳細が正確に表示される
- [x] 「精算をお願い」ボタンでLINE用メッセージがクリップボードにコピーされる
- [x] iPhone SEサイズでレイアウトが崩れない
- [x] ボタンの見栄えが適切である

🤖 Generated with [Claude Code](https://claude.ai/code)