### PR TITLE
feat: ヘッダーに「一覧」リンクを追加し、飲み会一覧ページを実装

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { Event } from '@/types'
+import { Calendar, MapPin, Users } from 'lucide-react'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+export default function EventsListPage() {
+  const [events, setEvents] = useState<Event[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchEvents()
+  }, [])
+
+  const fetchEvents = async () => {
+    try {
+      const response = await fetch('/api/events')
+      if (response.ok) {
+        const data = await response.json()
+        setEvents(data)
+      } else {
+        console.error('Failed to fetch events')
+      }
+    } catch (error) {
+      console.error('Error fetching events:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+  }
+
+  const formatCurrency = (amount: number) => {
+    return amount.toLocaleString()
+  }
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center">読み込み中...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">飲み会一覧</h1>
+        <p className="text-gray-600">作成した飲み会の一覧です。タイトルをクリックして詳細を確認できます。</p>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="text-center py-12">
+          <div className="text-gray-500 mb-4">まだ飲み会が作成されていません</div>
+          <Link
+            href="/events/new"
+            className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          >
+            新しい飲み会を作成
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {events.map((event) => (
+            <Link
+              key={event.id}
+              href={`/events/${event.id}`}
+              className="block bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-6 border hover:border-blue-300"
+            >
+              <div className="flex items-start justify-between mb-4">
+                <h2 className="text-xl font-semibold text-gray-900 hover:text-blue-600 transition-colors">
+                  {event.title}
+                </h2>
+                <div className="text-sm text-gray-500">
+                  {formatDate(event.eventDate)}
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-3 gap-4 text-sm text-gray-600">
+                <div className="flex items-center space-x-2">
+                  <Calendar className="w-4 h-4" />
+                  <span>{formatDate(event.eventDate)}</span>
+                </div>
+                
+                <div className="flex items-center space-x-2">
+                  <Users className="w-4 h-4" />
+                  <span>{event.participants.length}名参加</span>
+                </div>
+                
+                <div className="flex items-center space-x-2">
+                  <MapPin className="w-4 h-4" />
+                  <span>{event.venues.length}次会まで</span>
+                </div>
+              </div>
+
+              <div className="mt-4 pt-4 border-t">
+                <div className="flex items-center justify-between text-sm">
+                  <div className="text-gray-600">
+                    総額: ¥{formatCurrency(event.venues.reduce((sum, venue) => sum + venue.totalAmount, 0))}
+                  </div>
+                  <div className="text-blue-600 font-medium">
+                    詳細を見る →
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-8 text-center">
+        <Link
+          href="/events/new"
+          className="inline-flex items-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          新しい飲み会を作成
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Home, Settings } from 'lucide-react'
+import { Home, List, Settings } from 'lucide-react'
 import Link from 'next/link'
 
 export default function Header() {
@@ -23,14 +23,24 @@ export default function Header() {
             <span className="text-xl font-semibold">飲み会精算アプリ</span>
           </Link>
           
-          <Link 
-            href="/settings" 
-            onClick={handleSettingsClick}
-            className="flex items-center space-x-2 text-gray-600 hover:text-blue-600 transition-colors"
-          >
-            <Settings className="w-5 h-5" />
-            <span className="text-sm font-medium">設定</span>
-          </Link>
+          <div className="flex items-center space-x-4">
+            <Link 
+              href="/events" 
+              className="flex items-center space-x-2 text-gray-600 hover:text-blue-600 transition-colors"
+            >
+              <List className="w-5 h-5" />
+              <span className="text-sm font-medium">一覧</span>
+            </Link>
+            
+            <Link 
+              href="/settings" 
+              onClick={handleSettingsClick}
+              className="flex items-center space-x-2 text-gray-600 hover:text-blue-600 transition-colors"
+            >
+              <Settings className="w-5 h-5" />
+              <span className="text-sm font-medium">設定</span>
+            </Link>
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- ヘッダーの「設定」の横に「一覧」リンクを追加
- `/events`ページで作成した飲み会の一覧を表示する機能を実装
- 飲み会のタイトルをクリックすると詳細ページ（`events/:id`）に遷移

## 主な変更内容

### 1. ヘッダーコンポーネントの改善
- `Header.tsx`に「一覧」リンクを追加
- Listアイコンを使用して視覚的に分かりやすく表示
- 設定リンクと並べて配置し、適切な間隔を設定

### 2. 飲み会一覧ページの実装
- `/src/app/events/page.tsx`を新規作成
- APIから飲み会データを取得して一覧表示
- カード形式のレスポンシブUI

### 3. 表示機能
- **飲み会情報**: タイトル、開催日、参加者数、次会数、総額
- **インタラクティブ**: ホバー効果、クリック可能なカード
- **レスポンシブ**: モバイル・デスクトップ対応
- **空状態**: 飲み会が未作成の場合の案内

### 4. ナビゲーション
- 各飲み会カードをクリックで詳細ページに遷移
- 新しい飲み会作成ボタンを配置

## 実装された機能
- [x] ヘッダーに「一覧」リンクを追加
- [x] 飲み会一覧の表示
- [x] タイトルクリックでevents/:idページに遷移
- [x] レスポンシブデザイン
- [x] 空状態の処理
- [x] 新しい飲み会作成への誘導

## Test plan
- [ ] ヘッダーの「一覧」リンクが正常に表示される
- [ ] 一覧ページで飲み会データが正しく表示される
- [ ] 飲み会タイトルをクリックして詳細ページに遷移できる
- [ ] 飲み会が0件の場合に適切なメッセージが表示される
- [ ] モバイルデバイスでレイアウトが適切に表示される
- [ ] 新しい飲み会作成ボタンが機能する

🤖 Generated with [Claude Code](https://claude.ai/code)