### PR TITLE
本番環境デプロイ用設定 - Render + Neon Singapore

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# Renderデプロイ手順（Docker）
+# Renderデプロイ手順（Docker + Neon Database）
 
 ## 事前準備
 
@@ -6,23 +6,23 @@
 - [Render](https://render.com) でアカウントを作成
 - GitHubアカウントと連携
 
-### 2. PostgreSQLデータベース作成
-1. Render Dashboardで「New +」→「PostgreSQL」を選択
-2. Database Name: `kaisei-db`
-3. User: `kaisei_user` (任意)
-4. Region: `Oregon (US West)`
-5. Plan: `Free`
-6. 作成完了後、「External Database URL」をコピー
+### 2. Neonデータベース作成
+1. [Neon](https://neon.tech) でアカウントを作成
+2. 新しいプロジェクトを作成
+3. Database Name: `kaisei`
+4. Region: `Singapore (Asia Pacific)`
+5. 作成完了後、Connection String（DATABASE_URL）をコピー
+   - 形式例: `postgresql://username:password@ep-xxx.ap-southeast-1.aws.neon.tech/kaisei?sslmode=require`
 
 ### 3. Webサービス作成（Docker）
 1. Render Dashboardで「New +」→「Web Service」を選択
 2. GitHubリポジトリ `atsushimemet/kaisei` を選択
-3. Branch: `production-deploy`
+3. Branch: `main`
 4. 以下の設定を入力：
-   - Name: `kaisei-app`
+   - Name: `kaisei`
    - Environment: `Docker`
-   - Region: `Oregon (US West)`
-   - Branch: `production-deploy`
+   - Region: `Singapore (Southeast Asia)`
+   - Branch: `main`
    - Dockerfile Path: `./Dockerfile.prod`
    - Docker Build Context: `./`
 
@@ -31,12 +31,11 @@
 
 ```
 NODE_ENV=production
-DATABASE_URL=[Step2でコピーしたPostgreSQL URL]
-NEXTAUTH_URL=https://kaisei-app.onrender.com
+DATABASE_URL=[Step2でコピーしたNeon Database URL]
+NEXTAUTH_URL=https://kaisei.onrender.com
 NEXTAUTH_SECRET=[長いランダムな文字列を生成]
 GOOGLE_CLIENT_ID=[Google Console OAuth Client ID]
 GOOGLE_CLIENT_SECRET=[Google Console OAuth Client Secret]
-GOOGLE_MAPS_API_KEY=[Google Maps API Key]
 ```
 
 ### 5. データベースマイグレーション
@@ -49,9 +48,9 @@ npx prisma db push
 Google Cloud Consoleで：
 1. OAuth 2.0 クライアント設定を開く
 2. 承認済みのリダイレクト URIに追加：
-   - `https://kaisei-app.onrender.com/api/auth/callback/google`
+   - `https://kaisei.onrender.com/api/auth/callback/google`
 3. 承認済みのJavaScript生成元に追加：
-   - `https://kaisei-app.onrender.com`
+   - `https://kaisei.onrender.com`
 
 ## トラブルシューティング
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,77 @@
+# Renderデプロイ手順（Docker）
+
+## 事前準備
+
+### 1. Renderアカウント作成
+- [Render](https://render.com) でアカウントを作成
+- GitHubアカウントと連携
+
+### 2. PostgreSQLデータベース作成
+1. Render Dashboardで「New +」→「PostgreSQL」を選択
+2. Database Name: `kaisei-db`
+3. User: `kaisei_user` (任意)
+4. Region: `Oregon (US West)`
+5. Plan: `Free`
+6. 作成完了後、「External Database URL」をコピー
+
+### 3. Webサービス作成（Docker）
+1. Render Dashboardで「New +」→「Web Service」を選択
+2. GitHubリポジトリ `atsushimemet/kaisei` を選択
+3. Branch: `production-deploy`
+4. 以下の設定を入力：
+   - Name: `kaisei-app`
+   - Environment: `Docker`
+   - Region: `Oregon (US West)`
+   - Branch: `production-deploy`
+   - Dockerfile Path: `./Dockerfile.prod`
+   - Docker Build Context: `./`
+
+### 4. 環境変数設定
+以下の環境変数を設定：
+
+```
+NODE_ENV=production
+DATABASE_URL=[Step2でコピーしたPostgreSQL URL]
+NEXTAUTH_URL=https://kaisei-app.onrender.com
+NEXTAUTH_SECRET=[長いランダムな文字列を生成]
+GOOGLE_CLIENT_ID=[Google Console OAuth Client ID]
+GOOGLE_CLIENT_SECRET=[Google Console OAuth Client Secret]
+GOOGLE_MAPS_API_KEY=[Google Maps API Key]
+```
+
+### 5. データベースマイグレーション
+デプロイ後、Renderのシェルで以下を実行：
+```bash
+npx prisma db push
+```
+
+### 6. Google OAuth設定更新
+Google Cloud Consoleで：
+1. OAuth 2.0 クライアント設定を開く
+2. 承認済みのリダイレクト URIに追加：
+   - `https://kaisei-app.onrender.com/api/auth/callback/google`
+3. 承認済みのJavaScript生成元に追加：
+   - `https://kaisei-app.onrender.com`
+
+## トラブルシューティング
+
+### ビルドエラーが発生した場合
+- `npm run build` をローカルで実行して事前確認
+- TypeScriptエラーがないか確認
+
+### データベース接続エラー
+- `DATABASE_URL` が正しく設定されているか確認
+- Prismaマイグレーションが実行されているか確認
+
+### 認証エラー
+- `NEXTAUTH_SECRET` が設定されているか確認
+- Google OAuth設定が正しいか確認
+- リダイレクトURLが正しく登録されているか確認
+
+## 本番環境での確認事項
+- [ ] アプリケーションが正常に起動する
+- [ ] データベース接続が成功する
+- [ ] Google認証が正常に動作する
+- [ ] クイック精算が正常に動作する
+- [ ] ログイン済みユーザーの精算が正常に動作する
+- [ ] アクションボタン（コピー、ダウンロード、LINE共有）が正常に動作する

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,12 +1,19 @@
 FROM node:20-alpine AS builder
 
+# OpenSSLライブラリをインストール
+RUN apk add --no-cache openssl
+
 WORKDIR /app
 
 # パッケージファイルをコピー
 COPY package*.json ./
+COPY prisma ./prisma/
 
 # 依存関係をインストール
 RUN npm ci
+
+# Prismaクライアント生成
+RUN npx prisma generate
 
 # ソースコードをコピー
 COPY . .
@@ -17,19 +24,25 @@ RUN npm run build
 # 本番環境
 FROM node:20-alpine AS runner
 
+# OpenSSLライブラリをインストール
+RUN apk add --no-cache openssl
+
 WORKDIR /app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 # 必要なファイルのみをコピー
 COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 
 EXPOSE 3000
 
-ENV PORT 3000
-ENV HOSTNAME "0.0.0.0"
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 
 CMD ["node", "server.js"] 

--- a/env.example
+++ b/env.example
@@ -1,19 +1,16 @@
-# データベース設定（Renderから提供されるURL）
+# データベース設定（NeonまたはローカルPostgreSQL）
 DATABASE_URL="postgresql://kaisei_user:kaisei_password@localhost:5432/kaisei_dev"
-# 本番環境例: "postgresql://username:password@hostname:port/database"
+# 本番環境（Neon Singapore）例: "postgresql://username:password@ep-xxx.ap-southeast-1.aws.neon.tech/kaisei?sslmode=require"
 
 # NextAuth.js設定
 NEXTAUTH_URL="http://localhost:3000"
-# 本番環境例: "https://your-app-name.onrender.com"
+# 本番環境例: "https://kaisei.onrender.com"
 NEXTAUTH_SECRET="your-secret-key-here"
 # 本番環境では長いランダムな文字列を使用
 
 # Google認証設定
 GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
-
-# 外部API設定
-GOOGLE_MAPS_API_KEY="your-google-maps-api-key"
 
 # アプリケーション設定
 NODE_ENV="development"

--- a/env.example
+++ b/env.example
@@ -1,9 +1,12 @@
-# データベース設定
+# データベース設定（Renderから提供されるURL）
 DATABASE_URL="postgresql://kaisei_user:kaisei_password@localhost:5432/kaisei_dev"
+# 本番環境例: "postgresql://username:password@hostname:port/database"
 
 # NextAuth.js設定
 NEXTAUTH_URL="http://localhost:3000"
+# 本番環境例: "https://your-app-name.onrender.com"
 NEXTAUTH_SECRET="your-secret-key-here"
+# 本番環境では長いランダムな文字列を使用
 
 # Google認証設定
 GOOGLE_CLIENT_ID="your-google-client-id"
@@ -13,4 +16,5 @@ GOOGLE_CLIENT_SECRET="your-google-client-secret"
 GOOGLE_MAPS_API_KEY="your-google-maps-api-key"
 
 # アプリケーション設定
-NODE_ENV="development" 
+NODE_ENV="development"
+# 本番環境: "production" 

--- a/next.config.js
+++ b/next.config.js
@@ -2,13 +2,13 @@
 const nextConfig = {
   output: 'standalone',
   images: {
-    domains: ['localhost'],
+    domains: ['localhost', 'kaisei-app.onrender.com'],
   },
-  // CSS optimization for development
+  // CSS optimization for production
   experimental: {
-    optimizeCss: false,
+    optimizeCss: true,
   },
-  // Improve CSS loading in development
+  // Improve CSS loading
   webpack: (config, { dev }) => {
     if (dev) {
       config.optimization.splitChunks = {

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   output: 'standalone',
   images: {
-    domains: ['localhost', 'kaisei-app.onrender.com'],
+    domains: ['localhost', 'kaisei.onrender.com'],
   },
   // CSS optimization for production
   experimental: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,6 +440,36 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-arm64-gnu": {
       "version": "14.1.0",
       "cpu": [
@@ -463,6 +493,81 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+      "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+      "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -5426,111 +5531,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
-      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
-      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
-      "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
-      "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
-      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
-      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
-      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "type-check": "tsc --noEmit",
     "postinstall": "prisma generate",
     "db:push": "prisma db push",
-    "db:migrate": "prisma migrate dev",
+    "db:migrate": "prisma migrate deploy",
+    "db:migrate:dev": "prisma migrate dev",
     "db:generate": "prisma generate"
   },
   "dependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,8 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 // NextAuth.js Models

--- a/public/.gitkeep
+++ b/public/.gitkeep
@@ -1,0 +1,1 @@
+# This file ensures the public directory is tracked by git

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,25 @@
+services:
+  - type: web
+    name: kaisei-app
+    env: docker
+    dockerfilePath: ./Dockerfile.prod
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: NEXTAUTH_URL
+        sync: false  # Set manually in Render dashboard
+      - key: NEXTAUTH_SECRET
+        sync: false  # Set manually in Render dashboard
+      - key: DATABASE_URL
+        sync: false  # Set manually in Render dashboard
+      - key: GOOGLE_CLIENT_ID
+        sync: false  # Set manually in Render dashboard
+      - key: GOOGLE_CLIENT_SECRET
+        sync: false  # Set manually in Render dashboard
+      - key: GOOGLE_MAPS_API_KEY
+        sync: false  # Set manually in Render dashboard
+
+databases:
+  - name: kaisei-db
+    plan: free
+    region: oregon

--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,10 @@
 services:
   - type: web
-    name: kaisei-app
+    name: kaisei
     env: docker
     dockerfilePath: ./Dockerfile.prod
+    region: singapore
+    branch: main
     envVars:
       - key: NODE_ENV
         value: production
@@ -11,15 +13,10 @@ services:
       - key: NEXTAUTH_SECRET
         sync: false  # Set manually in Render dashboard
       - key: DATABASE_URL
-        sync: false  # Set manually in Render dashboard
+        sync: false  # Set manually in Render dashboard (Neon PostgreSQL Singapore URL)
       - key: GOOGLE_CLIENT_ID
         sync: false  # Set manually in Render dashboard
       - key: GOOGLE_CLIENT_SECRET
         sync: false  # Set manually in Render dashboard
-      - key: GOOGLE_MAPS_API_KEY
-        sync: false  # Set manually in Render dashboard
 
-databases:
-  - name: kaisei-db
-    plan: free
-    region: oregon
+# Note: Using external Neon database (Singapore region) instead of Render PostgreSQL

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -4,9 +4,9 @@ import { ArrowLeft, Calculator, Chrome, List, Shield } from 'lucide-react'
 import { getProviders, signIn, useSession } from 'next-auth/react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 
-export default function SignInPage() {
+function SignInContent() {
   const [providers, setProviders] = useState<any>(null)
   const [loading, setLoading] = useState(false)
   const router = useRouter()
@@ -137,5 +137,20 @@ export default function SignInPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+        <div className="bg-white rounded-xl shadow-xl p-8 text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">ページを読み込み中...</p>
+        </div>
+      </div>
+    }>
+      <SignInContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
本番環境（Render + Neon Database）への新規デプロイに必要な全ての設定を追加・修正しました。

## 主な変更内容

### 🚀 デプロイ環境設定
- **Render Webサービス**: シンガポールリージョン
- **Neon Database**: Singapore (Asia Pacific) リージョン
- **デプロイURL**: https://kaisei.onrender.com
- **デプロイブランチ**: main

### 🔧 技術的変更

#### データベース設定
- SQLite → PostgreSQL (Neon) に変更
- `prisma/schema.prisma` のデータソース更新
- Neonシンガポールリージョン用接続文字列

#### Docker本番環境対応
- `Dockerfile.prod` のOpenSSL依存関係修正
- Alpine LinuxでのPrisma動作保証
- マルチステージビルドでの最適化

#### NextAuth設定分離
- `authOptions` を `src/lib/auth.ts` に独立
- `@auth/prisma-adapter` への移行完了
- API routesでの型エラー解消

#### UI修正
- SignInページのSuspense境界問題修正
- useSearchParams()の適切な実装

### 📋 デプロイ用ファイル
- `render.yaml`: Render自動デプロイ設定
- `DEPLOYMENT.md`: 詳細なデプロイ手順書
- `Dockerfile.prod`: 本番環境用Docker設定
- `public/.gitkeep`: 静的ファイル用ディレクトリ

### 🌏 本番環境仕様
- **URL**: https://kaisei.onrender.com
- **リージョン**: Singapore (低レイテンシ)
- **データベース**: Neon PostgreSQL
- **認証**: Google OAuth 2.0
- **SSL**: 強制HTTPS

## 環境変数設定

本番環境で以下の環境変数設定が必要:

```
NODE_ENV=production
DATABASE_URL=[Neon PostgreSQL Singapore URL]
NEXTAUTH_URL=https://kaisei.onrender.com
NEXTAUTH_SECRET=[長いランダム文字列]
GOOGLE_CLIENT_ID=[Google OAuth Client ID]
GOOGLE_CLIENT_SECRET=[Google OAuth Client Secret]
```

## Test plan
- [x] Dockerビルドテスト成功
- [x] TypeScript型チェック通過
- [x] PostgreSQLスキーマ対応確認
- [x] NextAuthルート正常動作確認
- [x] 本番用CSS最適化有効確認

## デプロイ後確認事項
- [ ] Neonデータベース接続
- [ ] Prismaマイグレーション実行
- [ ] Google OAuth設定更新
- [ ] アプリケーション動作確認
- [ ] クイック精算・ログイン済み精算機能確認

🤖 Generated with [Claude Code](https://claude.ai/code)